### PR TITLE
Use proper API to get path to MyDocuments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ This template includes a copy of [playdate-luacats](https://github.com/notpeter/
      - Open the "Windows Powershell" application, copy and paste the following into the terminal, and then press enter:
 
         ```sh
-        [Environment]::SetEnvironmentVariable("PLAYDATE_SDK_PATH", "$env:USERPROFILE\Documents\PlaydateSDK", "User")
+       [Environment]::SetEnvironmentVariable("PLAYDATE_SDK_PATH", ([Environment]::GetFolderPath("MyDocuments"))+"\PlaydateSDK", "User")
         ```
      - If you installed the Playdate SDK at a different path, change the `$env:USERPROFILE\Documents\PlaydateSDK` part of the command to where you installed it
-     - To check if it worked correctly, close and reopen Powershell, type `$env:PLAYDATE_SDK_PATH`, and press enter. It should print the path to your `PlaydateSDK` folder
+     - To check if it worked correctly, close and reopen Powershell, type `cd $env:PLAYDATE_SDK_PATH`, and press enter. It should print the path to your `PlaydateSDK` folder
    - **Linux**
      - In a terminal window, type the following command to open your `.bashrc` file located in your Home directory using the nano text editor (replace `.bashrc` with `.zshrc` if your distro uses zsh instead of bash) 
        ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This template includes a copy of [playdate-luacats](https://github.com/notpeter/
         ```sh
        [Environment]::SetEnvironmentVariable("PLAYDATE_SDK_PATH", ([Environment]::GetFolderPath("MyDocuments"))+"\PlaydateSDK", "User")
         ```
-     - If you installed the Playdate SDK at a different path, change the `$env:USERPROFILE\Documents\PlaydateSDK` part of the command to where you installed it
+     - If you installed the Playdate SDK at a different path, change the `([Environment]::GetFolderPath("MyDocuments"))+"\PlaydateSDK"` part of the command to where you installed it
      - To check if it worked correctly, close and reopen Powershell, type `cd $env:PLAYDATE_SDK_PATH`, and press enter. It should print the path to your `PlaydateSDK` folder
    - **Linux**
      - In a terminal window, type the following command to open your `.bashrc` file located in your Home directory using the nano text editor (replace `.bashrc` with `.zshrc` if your distro uses zsh instead of bash) 


### PR DESCRIPTION
The original code fails for me because my My Documents is located in OneDrive and also it's not in English.

Maybe putting the SDK in the OneDrive My Documents is not ideal, but it's the default in the installer.
Also, use cd to check if the SDK is reachable.

```
PS C:\Users\erikl> cd $env:PLAYDATE_SDK_PATH
cd : Cannot find path 'C:\Users\erikl\Documents\PlaydateSDK' because it does not exist.
At line:1 char:1
+ cd $env:PLAYDATE_SDK_PATH
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\erikl\Documents\PlaydateSDK:String) [Set-Location], ItemNotFou
   ndException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand
```
